### PR TITLE
Release v1.1.4

### DIFF
--- a/class-skyverge-plugin-updater.php
+++ b/class-skyverge-plugin-updater.php
@@ -605,10 +605,14 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginUpdater\\Updater' ) ) :
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param string $value
+		 * @param mixed|object $value
 		 * @param string $cache_key
 		 */
 		public function set_version_info_cache( $value = '', $cache_key = '' ) {
+
+			if ( ! is_object( $value ) ) {
+				$value = new \stdClass();
+			}
 
 			if ( empty( $cache_key ) ) {
 				$cache_key = $this->cache_key;

--- a/class-skyverge-plugin-updater.php
+++ b/class-skyverge-plugin-updater.php
@@ -130,7 +130,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginUpdater\\Updater' ) ) :
 			global $pagenow;
 
 			if ( ! is_object( $_transient_data ) ) {
-				$_transient_data = new \stdClass;
+				$_transient_data = new \stdClass();
 			}
 
 			if ( 'plugins.php' === $pagenow && is_multisite() ) {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "skyverge/wc-plugin-updater",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "WooCommerce Plugin Updater",
 	"license": "GPL 3.0",
 	"authors": [


### PR DESCRIPTION
## Summary

Fixes a possible PHP Warning if properties are assigned to an object that hasn't been initialized. 

### [MWC 1331](https://jira.godaddy.com/browse/MWC-1331)

## QA

Unfortunately it is not easy to replicate this issue because it is dependent on the response received from the plugin updater API. As the code stands now, `set_version_info_cache( $value )` may accept for argument other types than `object stdClass` but in the body it would try to set a `$value->icons` property on it. If `$value` is a non object, or is `null`, then it should trigger the error reported by some customers.

Personally I don't see why `$value` should be anything else than `stdClass` and I'm not sure why the method was written in such a way to accept a string or other types.

- [x] Code review

### After merge

- [ ] Issue a new release of the updater
- [ ] All plugins implementing this (Shipping Estimates, SkyVerge Dashboard...) should issue a new update with the latest version of this library

