### PR TITLE
MWC-3452 - PHP warning when running Shipping Estimates and Dashboard [6]

### DIFF
--- a/class-skyverge-plugin-updater.php
+++ b/class-skyverge-plugin-updater.php
@@ -395,21 +395,24 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginUpdater\\Updater' ) ) :
 				'body'      => $api_params,
 			] );
 
-			if ( ! is_wp_error( $request ) ) {
-				$request = json_decode( wp_remote_retrieve_body( $request ) );
+			if ( is_wp_error( $request ) ) {
+				return false;
 			}
 
-			if ( $request && isset( $request->sections ) ) {
+			$request = json_decode( wp_remote_retrieve_body( $request ) );
+			if ( ! is_object( $request ) ) {
+				return false;
+			}
+
+			if ( isset( $request->sections ) ) {
 				$request->sections = maybe_unserialize( $request->sections );
-			} else {
-				$request = false;
 			}
 
-			if ( $request && isset( $request->banners ) ) {
+			if ( isset( $request->banners ) ) {
 				$request->banners = maybe_unserialize( $request->banners );
 			}
 
-			if ( $request && isset( $request->icons ) ) {
+			if ( isset( $request->icons ) ) {
 				$request->icons = maybe_unserialize( $request->icons );
 			}
 


### PR DESCRIPTION
## Issue: [MWC-3452](https://jira.godaddy.com/browse/MWC-3452)

I made a fork as I don't have write access to this repo.

## Details

I've refactored the code slightly to exit early if we don't have a valid `$request` object. This prevents [the error happening on line 430](https://github.com/skyverge/wc-plugin-updater/blob/master/class-skyverge-plugin-updater.php#L430) because we'll never get to that point if `$request` is not an object.